### PR TITLE
refactor(captin): extract interface on models

### DIFF
--- a/destinations/filters/base.go
+++ b/destinations/filters/base.go
@@ -4,7 +4,13 @@ import (
 	models "github.com/shoplineapp/captin/models"
 )
 
-type Filter interface {
-	Run(e models.IncomingEvent, c models.Configuration) (bool, error)
-	Applicable(e models.IncomingEvent, c models.Configuration) bool
+// DestinationMiddleware - Interface for third-party application to add extra handling on destinations
+type DestinationMiddlewareInterface interface {
+	Apply(e *models.IncomingEvent, d []models.Destination) []models.Destination
+}
+
+// DestinationFilter - Interface for third-party application to filter destination by event
+type DestinationFilterInterface interface {
+	Run(e models.IncomingEvent, c models.Destination) (bool, error)
+	Applicable(e models.IncomingEvent, c models.Destination) bool
 }

--- a/destinations/filters/desired_hook.go
+++ b/destinations/filters/desired_hook.go
@@ -1,7 +1,6 @@
 package destination_filters
 
 import (
-	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 )
 
@@ -24,12 +23,12 @@ func stringList(list []interface{}) []string {
 
 // DesiredHookFilter - Filter destination if given event has desired destination
 type DesiredHookFilter struct {
-	interfaces.DestinationFilter
+	DestinationFilterInterface
 }
 
 // Run - Get desired hooks in control and filter out exclusion
 func (f DesiredHookFilter) Run(e models.IncomingEvent, d models.Destination) (bool, error) {
-	hook := d.Config.Name
+	hook := d.Config.GetName()
 	list := e.Control["desired_hooks"]
 	switch list.(type) {
 	case []interface{}:

--- a/destinations/filters/environment.go
+++ b/destinations/filters/environment.go
@@ -1,7 +1,6 @@
 package destination_filters
 
 import (
-	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -9,7 +8,7 @@ import (
 var eLogger = log.WithFields(log.Fields{"class": "EnvironmentFilter"})
 
 type EnvironmentFilter struct {
-	interfaces.DestinationFilter
+	DestinationFilterInterface
 }
 
 // Destination needs to be enabled by ENV Variable {Config Name}_ENABLED, e.g, WAPOS_SYNC_ENABLED

--- a/destinations/filters/source.go
+++ b/destinations/filters/source.go
@@ -1,18 +1,17 @@
 package destination_filters
 
 import (
-	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 )
 
 type SourceFilter struct {
-	interfaces.DestinationFilter
+	DestinationFilterInterface
 }
 
 func (f SourceFilter) Run(e models.IncomingEvent, d models.Destination) (bool, error) {
-	return e.Source != d.Config.Source, nil
+	return e.Source != d.Config.GetSource(), nil
 }
 
 func (f SourceFilter) Applicable(e models.IncomingEvent, d models.Destination) bool {
-	return d.Config.AllowLoopback == false
+	return d.Config.GetAllowLoopback() == false
 }

--- a/destinations/filters/validate.go
+++ b/destinations/filters/validate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/robertkrimen/otto"
-	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -12,7 +11,7 @@ import (
 var vLogger = log.WithFields(log.Fields{"class": "ValidateFilter"})
 
 type ValidateFilter struct {
-	interfaces.DestinationFilter
+	DestinationFilterInterface
 }
 
 func (f ValidateFilter) Run(e models.IncomingEvent, d models.Destination) (bool, error) {
@@ -41,5 +40,5 @@ func (f ValidateFilter) Run(e models.IncomingEvent, d models.Destination) (bool,
 }
 
 func (f ValidateFilter) Applicable(e models.IncomingEvent, d models.Destination) bool {
-	return (d.Config.Validate) != ""
+	return (d.Config.GetValidate()) != ""
 }

--- a/errors/dispatcher_error.go
+++ b/errors/dispatcher_error.go
@@ -2,12 +2,14 @@ package errors
 
 import (
 	"fmt"
+	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 )
 
 // DispatcherError - Error when send events
 type DispatcherError struct {
-	ErrorInterface
+	interfaces.ErrorInterface
+
 	Msg         string
 	Event       models.IncomingEvent
 	Destination models.Destination

--- a/errors/execution_error.go
+++ b/errors/execution_error.go
@@ -2,11 +2,13 @@ package errors
 
 import (
 	"fmt"
+	interfaces "github.com/shoplineapp/captin/interfaces"
 )
 
 // ExecutionError - Error on executing events
 type ExecutionError struct {
-	ErrorInterface
+	interfaces.ErrorInterface
+
 	Cause string
 }
 

--- a/interfaces/document_store.go
+++ b/interfaces/document_store.go
@@ -1,11 +1,7 @@
 package interfaces
 
-import (
-  models "github.com/shoplineapp/captin/models"
-)
-
 // StoreInterface - Store for throttle events
 type DocumentStoreInterface interface {
   // GetDocument - Get value from store, return the document map
-  GetDocument(e models.IncomingEvent) (map[string]interface{})
+  GetDocument(e IncomingEventInterface) (map[string]interface{})
 }

--- a/interfaces/errors.go
+++ b/interfaces/errors.go
@@ -1,4 +1,4 @@
-package errors
+package interfaces
 
 type ErrorInterface interface {
 	Error() string

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -2,19 +2,16 @@ package interfaces
 
 import (
 	"time"
-
-	captin_errors "github.com/shoplineapp/captin/errors"
-	models "github.com/shoplineapp/captin/models"
 )
 
 // CaptinInterface - Captin Interface
 type CaptinInterface interface {
-	Execute(e models.IncomingEvent) (bool, []captin_errors.ErrorInterface)
+	Execute(e IncomingEventInterface) (bool, []ErrorInterface)
 }
 
 // EventSenderInterface - Event Sender Interface
 type EventSenderInterface interface {
-	SendEvent(e models.IncomingEvent, d models.Destination) error
+	SendEvent(e IncomingEventInterface, d DestinationInterface) error
 }
 
 // ThrottleInterface - interface for a throttle object
@@ -26,4 +23,8 @@ type EventSenderInterface interface {
 type ThrottleInterface interface {
 	// CanTrigger - Check if can trigger
 	CanTrigger(id string, period time.Duration) (bool, time.Duration, error)
+}
+
+type ErrorHandlerInterface interface {
+	Exec(e ErrorInterface)
 }

--- a/interfaces/models.go
+++ b/interfaces/models.go
@@ -1,19 +1,8 @@
 package interfaces
 
 import (
-	models "github.com/shoplineapp/captin/models"
+	"time"
 )
-
-// DestinationMiddleware - Interface for third-party application to add extra handling on destinations
-type DestinationMiddleware interface {
-	Apply(e *models.IncomingEvent, d []models.Destination) []models.Destination
-}
-
-// DestinationFilter - Interface for third-party application to filter destination by event
-type DestinationFilter interface {
-	Run(e models.IncomingEvent, c models.Destination) (bool, error)
-	Applicable(e models.IncomingEvent, c models.Destination) bool
-}
 
 // IncomingHandler - Interface for creating handler to trigger captin execute
 type IncomingHandler interface {
@@ -23,5 +12,40 @@ type IncomingHandler interface {
 
 // ConfigMapperInterface - Interface for config mapper
 type ConfigMapperInterface interface {
-	ConfigsForKey(eventKey string) []models.Configuration
+	ConfigsForKey(eventKey string) []ConfigurationInterface
+}
+
+type IncomingEventInterface interface {
+	GetTraceInfo() map[string]interface{}
+	IsValid() bool
+}
+
+type DestinationInterface interface {
+	GetCallbackURL() string
+	GetDocumentStore() string
+}
+
+type ConfigurationInterface interface {
+	GetByEnv(key string) (string, string)
+	GetThrottleValue() time.Duration
+	GetDelayValue() time.Duration
+	GetTimeValueMillis(timeValue string) time.Duration
+	GetActions() []string
+	GetConfigID() string
+	GetCallbackURL() string
+	GetValidate() string
+	GetSource() string
+	GetThrottle() string
+	GetDelay() string
+	GetThrottleTrailingDisabled() bool
+	GetIncludeDocument() bool
+	GetName() string
+	GetAllowLoopback() bool
+	GetSender() string
+	GetDocumentStore() string
+	GetIncludeDocumentAttrs() []string
+	GetExcludeDocumentAttrs() []string
+	GetIncludePayloadAttrs() []string
+	GetExcludePayloadAttrs() []string
+	GetExtras() map[string]string
 }

--- a/interfaces/store.go
+++ b/interfaces/store.go
@@ -2,8 +2,6 @@ package interfaces
 
 import (
 	"time"
-
-	models "github.com/shoplineapp/captin/models"
 )
 
 // StoreInterface - Store for throttle events
@@ -20,5 +18,5 @@ type StoreInterface interface {
 	// Remove - Remove value for key
 	Remove(key string) (bool, error)
 
-	DataKey(e models.IncomingEvent, dest models.Destination, prefix string, suffix string) string
+	DataKey(e IncomingEventInterface, dest DestinationInterface, prefix string, suffix string) string
 }

--- a/internal/document_stores/null_store.go
+++ b/internal/document_stores/null_store.go
@@ -2,7 +2,6 @@ package document_stores
 
 import (
   interfaces "github.com/shoplineapp/captin/interfaces"
-  "github.com/shoplineapp/captin/models"
 )
 
 // NullDocumentStore - Null data store
@@ -16,6 +15,7 @@ func NewNullDocumentStore() *NullDocumentStore {
 }
 
 // Get - Get value from store, return with remaining time
-func (ms NullDocumentStore) GetDocument(e models.IncomingEvent) (map[string]interface{}) {
+func (ms NullDocumentStore) GetDocument(e interfaces.IncomingEventInterface) (map[string]interface{}) {
   return map[string]interface{}{}
 }
+

--- a/internal/outgoing/custom.go
+++ b/internal/outgoing/custom.go
@@ -1,8 +1,8 @@
 package outgoing
 
 import (
-	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
+	destination_filters "github.com/shoplineapp/captin/destinations/filters"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -11,9 +11,9 @@ var cLogger = log.WithFields(log.Fields{"class": "Custom"})
 type Custom struct{}
 
 // Sift - Custom check will filter ineligible destination
-func (c Custom) Sift(e *models.IncomingEvent, destinations []models.Destination, filters []interfaces.DestinationFilter, middlewares []interfaces.DestinationMiddleware) []models.Destination {
+func (c Custom) Sift(e *models.IncomingEvent, destinations []models.Destination, filters []destination_filters.DestinationFilterInterface, middlewares []destination_filters.DestinationMiddlewareInterface) []models.Destination {
 	cLogger.WithFields(log.Fields{
-		"event":        e,
+		"event":        e.GetTraceInfo(),
 		"destinations": destinations,
 		"filters":      filters,
 		"middlewares":  middlewares,
@@ -37,5 +37,6 @@ func (c Custom) Sift(e *models.IncomingEvent, destinations []models.Destination,
 	for _, m := range middlewares {
 		sifted = m.Apply(e, sifted)
 	}
+
 	return sifted
 }

--- a/internal/stores/memstore.go
+++ b/internal/stores/memstore.go
@@ -101,6 +101,8 @@ func (ms *MemoryStore) Len() int {
 }
 
 // DataKey - Generate DataKey with events and destination
-func (ms *MemoryStore) DataKey(e models.IncomingEvent, dest models.Destination, prefix string, suffix string) string {
-	return fmt.Sprintf("%s%s.%s.%s%s", prefix, e.Key, dest.Config.Name, e.TargetId, suffix)
+func (ms *MemoryStore) DataKey(ev interfaces.IncomingEventInterface, dest interfaces.DestinationInterface, prefix string, suffix string) string {
+	e := ev.(models.IncomingEvent)
+	config := dest.(models.Destination).Config
+	return fmt.Sprintf("%s%s.%s.%s%s", prefix, e.Key, config.GetName(), e.TargetId, suffix)
 }

--- a/models/config.go
+++ b/models/config.go
@@ -7,10 +7,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"github.com/shoplineapp/captin/interfaces"
 )
 
 // Configuration - Webhook Configuration Model
 type Configuration struct {
+	interfaces.ConfigurationInterface
+
 	ConfigID                 string            `json:"id"`
 	CallbackURL              string            `json:"callback_url"`
 	Validate                 string            `json:"validate"`
@@ -71,4 +74,76 @@ func (c Configuration) GetTimeValueMillis(timeValue string) time.Duration {
 	}
 
 	return 0
+}
+
+func (c Configuration) GetActions() []string {
+	return c.Actions
+}
+
+func (c Configuration) GetConfigID() string {
+	return c.ConfigID
+}
+
+func (c Configuration) GetCallbackURL() string {
+	return c.CallbackURL
+}
+
+func (c Configuration) GetValidate() string {
+	return c.Validate
+}
+
+func (c Configuration) GetSource() string {
+	return c.Source
+}
+
+func (c Configuration) GetThrottle() string {
+	return c.Throttle
+}
+
+func (c Configuration) GetDelay() string {
+	return c.Delay
+}
+
+func (c Configuration) GetThrottleTrailingDisabled() bool {
+	return c.ThrottleTrailingDisabled
+}
+
+func (c Configuration) GetIncludeDocument() bool {
+	return c.IncludeDocument
+}
+
+func (c Configuration) GetName() string {
+	return c.Name
+}
+
+func (c Configuration) GetAllowLoopback() bool {
+	return c.AllowLoopback
+}
+
+func (c Configuration) GetSender() string {
+	return c.Sender
+}
+
+func (c Configuration) GetDocumentStore() string {
+	return c.DocumentStore
+}
+
+func (c Configuration) GetIncludeDocumentAttrs() []string {
+	return c.IncludeDocumentAttrs
+}
+
+func (c Configuration) GetExcludeDocumentAttrs() []string {
+	return c.ExcludeDocumentAttrs
+}
+
+func (c Configuration) GetIncludePayloadAttrs() []string {
+	return c.IncludePayloadAttrs
+}
+
+func (c Configuration) GetExcludePayloadAttrs() []string {
+	return c.ExcludePayloadAttrs
+}
+
+func (c Configuration) GetExtras() map[string]string {
+	return c.Extras
 }

--- a/models/config_mapper.go
+++ b/models/config_mapper.go
@@ -5,28 +5,28 @@ import (
 	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
+	interfaces "github.com/shoplineapp/captin/interfaces"
 )
 
 var cmLogger = log.WithFields(log.Fields{"class": "ConfigurationMapper"})
 
 // ConfigurationMapper - Action to configuration mapper
 type ConfigurationMapper struct {
-	ActionMap map[string][]Configuration
+	ActionMap map[string][]interfaces.ConfigurationInterface
 }
 
 // NewConfigurationMapper - Create ConfigurationMapper with array of Configurations
-func NewConfigurationMapper(configs []Configuration) *ConfigurationMapper {
+func NewConfigurationMapper(configs []interfaces.ConfigurationInterface) *ConfigurationMapper {
 	result := ConfigurationMapper{
-		ActionMap: make(map[string][]Configuration),
+		ActionMap: make(map[string][]interfaces.ConfigurationInterface),
 	}
 	for _, config := range configs {
-		for _, action := range config.Actions {
+		for _, action := range config.GetActions() {
 			list := result.ActionMap[action]
 			list = append(list, config)
 			result.ActionMap[action] = list
 		}
 	}
-
 	return &result
 }
 
@@ -40,16 +40,20 @@ func NewConfigurationMapperFromPath(path string) *ConfigurationMapper {
 		panic(err)
 	}
 
-	configs := []Configuration{}
-	jsonErr := json.Unmarshal(data, &configs)
+	raw := []Configuration{}
+	jsonErr := json.Unmarshal(data, &raw)
 	if jsonErr != nil {
 		pathLogger.Error("Invalid configuration file format")
 		panic(jsonErr)
 	}
 
+	configs := []interfaces.ConfigurationInterface{}
+	for _, c := range raw {
+		configs = append(configs, c)
+	}
 	return NewConfigurationMapper(configs)
 }
 
-func (cm ConfigurationMapper) ConfigsForKey(eventKey string) []Configuration {
+func (cm ConfigurationMapper) ConfigsForKey(eventKey string) []interfaces.ConfigurationInterface {
 	return cm.ActionMap[eventKey]
 }

--- a/models/destination.go
+++ b/models/destination.go
@@ -1,25 +1,39 @@
 package models
 
+import (
+	interfaces "github.com/shoplineapp/captin/interfaces"
+)
+
 // Destination - Event dispatch destination
 type Destination struct {
-	Config Configuration
+	interfaces.DestinationInterface
+
+	Config interfaces.ConfigurationInterface
+	callbackUrl string
+}
+
+func (d *Destination) SetCallbackURL(url string) {
+	d.callbackUrl = url
 }
 
 func (d Destination) GetCallbackURL() string {
 	_, value := d.Config.GetByEnv("callback_url")
-	if len(value) == 0 {
-		value = d.Config.CallbackURL
+	if len(value) > 0 {
+		return value
 	}
-	return value
+	if len(d.callbackUrl) > 0 {
+		return d.callbackUrl
+	}
+	return d.Config.GetCallbackURL()
 }
 
 func (d Destination) GetDocumentStore() string {
 	_, value := d.Config.GetByEnv("document_store")
 	if len(value) == 0 {
-		if len(d.Config.DocumentStore) == 0 {
+		if len(d.Config.GetDocumentStore()) == 0 {
 			return "default"
 		}
-		return d.Config.DocumentStore
+		return d.Config.GetDocumentStore()
 	}
 	return value
 }

--- a/models/incoming_event.go
+++ b/models/incoming_event.go
@@ -3,9 +3,13 @@ package models
 import (
 	"encoding/json"
 	"github.com/google/uuid"
+
+	interfaces "github.com/shoplineapp/captin/interfaces"
 )
 
 type IncomingEvent struct {
+	interfaces.IncomingEventInterface
+
 	TraceId string
 	Key     string                 `json:"event_key"` // Required, The identifier of an event, usually form as PREFIX.MODEL.ACTION
 	Source  string                 `json:"source"`    // Required, Event source from
@@ -21,7 +25,11 @@ type IncomingEvent struct {
 func NewIncomingEvent(data []byte) IncomingEvent {
 	e := IncomingEvent{}
 	json.Unmarshal(data, &e)
-	e.TraceId = uuid.New().String()
+
+	// Reuse trace ID if it's given for tracing retry with the same ID
+	if e.TraceId == "" {
+		e.TraceId = uuid.New().String()
+	}
 	return e
 }
 

--- a/senders/beanstlakd_sender.go
+++ b/senders/beanstlakd_sender.go
@@ -1,75 +1,75 @@
 package senders
 
 import (
-  "encoding/json"
-  "time"
+	"encoding/json"
+	"time"
 
-  interfaces "github.com/shoplineapp/captin/interfaces"
-  models "github.com/shoplineapp/captin/models"
-  beanstalk "github.com/beanstalkd/go-beanstalk"
-  log "github.com/sirupsen/logrus"
+	beanstalk "github.com/beanstalkd/go-beanstalk"
+	interfaces "github.com/shoplineapp/captin/interfaces"
+	models "github.com/shoplineapp/captin/models"
+	log "github.com/sirupsen/logrus"
 )
 
 var bLogger = log.WithFields(log.Fields{"class": "BeanstalkdSender"})
 
 // BeanstalkdSender - Send Event to beanstalkd
 type BeanstalkdSender struct {
-  interfaces.EventSenderInterface
+	interfaces.EventSenderInterface
 }
 
 // SendEvent - #BeanstalkdSender SendEvent
-func (c *BeanstalkdSender) SendEvent(e models.IncomingEvent, d models.Destination) error {
-  conn, err := beanstalk.Dial("tcp", e.Control["beanstalkd_host"].(string))
-  if err != nil {
-    bLogger.WithFields(log.Fields{
-      "error": err,
-    }).Error("Beanstalk create connection failed.")
-    return err
-  }
+func (c *BeanstalkdSender) SendEvent(ev interfaces.IncomingEventInterface, dv interfaces.DestinationInterface) error {
+	e := ev.(models.IncomingEvent)
+	conn, err := beanstalk.Dial("tcp", e.Control["beanstalkd_host"].(string))
+	if err != nil {
+		bLogger.WithFields(log.Fields{
+			"error": err,
+		}).Error("Beanstalk create connection failed.")
+		return err
+	}
 
-  conn.Tube = beanstalk.Tube { Conn: conn, Name: e.Control["queue_name"].(string) }
+	conn.Tube = beanstalk.Tube{Conn: conn, Name: e.Control["queue_name"].(string)}
 
-  jobBody, err := json.Marshal(e.Payload)
-  if err != nil {
-    bLogger.WithFields(log.Fields{
-      "error": err,
-    }).Error("Beanstalkd job payload format invalid.")
-    return err
-  }
+	jobBody, err := json.Marshal(e.Payload)
+	if err != nil {
+		bLogger.WithFields(log.Fields{
+			"error": err,
+		}).Error("Beanstalkd job payload format invalid.")
+		return err
+	}
 
-  pri := uint32(65536)
-  var delay time.Duration
-  ttr := time.Duration(time.Minute)
+	pri := uint32(65536)
+	var delay time.Duration
+	ttr := time.Duration(time.Minute)
 
-  if e.Control["priority"] != nil {
-    pri = e.Control["priority"].(uint32)
-  }
+	if e.Control["priority"] != nil {
+		pri = e.Control["priority"].(uint32)
+	}
 
-  if e.Control["delay"] != nil {
-    delay, _ = time.ParseDuration(e.Control["delay"].(string))
-  }
+	if e.Control["delay"] != nil {
+		delay, _ = time.ParseDuration(e.Control["delay"].(string))
+	}
 
-  if e.Control["ttr"] != nil {
-    ttr, _ = time.ParseDuration(e.Control["ttr"].(string))
-  }
+	if e.Control["ttr"] != nil {
+		ttr, _ = time.ParseDuration(e.Control["ttr"].(string))
+	}
 
-  id, err := conn.Put(jobBody, pri, time.Duration(delay), time.Duration(ttr))
-  if err != nil {
-    bLogger.WithFields(log.Fields{
-      "error": err,
-    }).Error("Beanstalk client put job failed.")
-    return err
-  }
+	id, err := conn.Put(jobBody, pri, time.Duration(delay), time.Duration(ttr))
+	if err != nil {
+		bLogger.WithFields(log.Fields{
+			"error": err,
+		}).Error("Beanstalk client put job failed.")
+		return err
+	}
 
-  bLogger.WithFields(log.Fields{
-    "id": id,
-    "pri": pri,
-    "delay": delay,
-    "ttr": ttr,
-    "jobBody": string(jobBody),
-  }).Info("Enqueue job.")
+	bLogger.WithFields(log.Fields{
+		"id":      id,
+		"pri":     pri,
+		"delay":   delay,
+		"ttr":     ttr,
+		"jobBody": string(jobBody),
+	}).Info("Enqueue job.")
 
-  defer conn.Close()
-  return nil
+	defer conn.Close()
+	return nil
 }
-

--- a/senders/console_sender.go
+++ b/senders/console_sender.go
@@ -1,6 +1,7 @@
 package senders
 
 import (
+	interfaces "github.com/shoplineapp/captin/interfaces"
 	models "github.com/shoplineapp/captin/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -11,9 +12,12 @@ var cLogger = log.WithFields(log.Fields{"class": "ConsoleEventSender"})
 type ConsoleEventSender struct{}
 
 // SendEvent - #ConsoleEventSender SendEvent
-func (c *ConsoleEventSender) SendEvent(e models.IncomingEvent, d models.Destination) error {
+func (c *ConsoleEventSender) SendEvent(ev interfaces.IncomingEventInterface, dv interfaces.DestinationInterface) error {
+	e := ev.(models.IncomingEvent)
+	d := dv.(models.Destination)
+
 	cLogger.WithFields(log.Fields{
-		"config_name": d.Config.Name,
+		"config_name": d.Config.GetName(),
 		"target_id":   e.TargetId,
 		"target_type": e.TargetType,
 		"target_document": e.TargetDocument,

--- a/senders/http_proxy_sender.go
+++ b/senders/http_proxy_sender.go
@@ -31,7 +31,10 @@ type HTTPProxyEventSender struct {
 }
 
 // SendEvent - #HTTPProxyEventSender SendEvent
-func (c *HTTPProxyEventSender) SendEvent(e models.IncomingEvent, d models.Destination) error {
+func (c *HTTPProxyEventSender) SendEvent(ev interfaces.IncomingEventInterface, dv interfaces.DestinationInterface) error {
+	e := ev.(models.IncomingEvent)
+	d := dv.(models.Destination)
+
 	url := d.GetCallbackURL()
 	payload, err := json.Marshal(e.Payload)
 

--- a/senders/http_sender.go
+++ b/senders/http_sender.go
@@ -27,7 +27,10 @@ type HTTPEventSender struct {
 }
 
 // SendEvent - #HttpEventSender SendEvent
-func (c *HTTPEventSender) SendEvent(e models.IncomingEvent, d models.Destination) error {
+func (c *HTTPEventSender) SendEvent(ev interfaces.IncomingEventInterface, dv interfaces.DestinationInterface) error {
+	e := ev.(models.IncomingEvent)
+	d := dv.(models.Destination)
+
 	url := d.GetCallbackURL()
 	payload, err := json.Marshal(e)
 

--- a/senders/sqs_sender.go
+++ b/senders/sqs_sender.go
@@ -34,7 +34,10 @@ func NewSqsSender(awsConfig aws.Config) *SqsSender {
 }
 
 // SendEvent - Send incoming event into SQS queue
-func (s *SqsSender) SendEvent(e models.IncomingEvent, d models.Destination) error {
+func (s *SqsSender) SendEvent(ev interfaces.IncomingEventInterface, dv interfaces.DestinationInterface) error {
+	e := ev.(models.IncomingEvent)
+	d := dv.(models.Destination)
+
 	queueURL := d.GetCallbackURL()
 	sLogger.WithFields(log.Fields{"queueURL": queueURL}).Debug("Send sqs event")
 

--- a/test/core/captin_test.go
+++ b/test/core/captin_test.go
@@ -35,7 +35,7 @@ func TestNewCaptin(t *testing.T) {
 
 func TestExecute(t *testing.T) {
 	// When event is not given or is invalid
-	var errors []captin_errors.ErrorInterface
+	var errors []interfaces.ErrorInterface
 
 	_, errors = Captin{}.Execute(models.IncomingEvent{})
 

--- a/test/internal/outgoing/custom_test.go
+++ b/test/internal/outgoing/custom_test.go
@@ -3,7 +3,7 @@ package outgoing_test
 import (
 	"testing"
 
-	interfaces "github.com/shoplineapp/captin/interfaces"
+	destination_filters "github.com/shoplineapp/captin/destinations/filters"
 	. "github.com/shoplineapp/captin/internal/outgoing"
 	models "github.com/shoplineapp/captin/models"
 	"github.com/stretchr/testify/assert"
@@ -43,10 +43,10 @@ func TestCustom_Sift(t *testing.T) {
 	middleware := new(MiddlewareMock)
 	middleware.On("Apply", mock.Anything, mock.Anything)
 	destinations := []models.Destination{
-		{Config: models.Configuration{Source: "service_1"}},
-		{Config: models.Configuration{Source: "service_2"}},
+		models.Destination{Config: models.Configuration{Source: "service_1"}},
+		models.Destination{Config: models.Configuration{Source: "service_2"}},
 	}
-	sifted := Custom{}.Sift(&event, destinations, []interfaces.DestinationFilter{filter}, []interfaces.DestinationMiddleware{middleware})
+	sifted := Custom{}.Sift(&event, destinations, []destination_filters.DestinationFilterInterface{filter}, []destination_filters.DestinationMiddlewareInterface{middleware})
 	filter.AssertNumberOfCalls(t, "Applicable", 2)
 	filter.AssertNumberOfCalls(t, "Run", 2)
 	middleware.AssertNumberOfCalls(t, "Apply", 1)
@@ -59,10 +59,10 @@ func TestCustom_Sift(t *testing.T) {
 	middleware = new(MiddlewareMock)
 	middleware.On("Apply", mock.Anything, mock.Anything)
 	destinations = []models.Destination{
-		{Config: models.Configuration{Source: "service_1"}},
-		{Config: models.Configuration{Source: "service_2"}},
+		models.Destination{Config: models.Configuration{Source: "service_1"}},
+		models.Destination{Config: models.Configuration{Source: "service_2"}},
 	}
-	sifted = Custom{}.Sift(&event, destinations, []interfaces.DestinationFilter{filter}, []interfaces.DestinationMiddleware{middleware})
+	sifted = Custom{}.Sift(&event, destinations, []destination_filters.DestinationFilterInterface{filter}, []destination_filters.DestinationMiddlewareInterface{middleware})
 	filter.AssertNumberOfCalls(t, "Applicable", 2)
 	filter.AssertNumberOfCalls(t, "Run", 0)
 	middleware.AssertNumberOfCalls(t, "Apply", 1)
@@ -75,9 +75,9 @@ func TestCustom_Sift(t *testing.T) {
 	middleware = new(MiddlewareMock)
 	middleware.On("Apply", mock.Anything, mock.Anything)
 	destinations = []models.Destination{
-		{Config: models.Configuration{Source: "service_1"}},
+		models.Destination{Config: models.Configuration{Source: "service_1"}},
 	}
-	sifted = Custom{}.Sift(&event, destinations, []interfaces.DestinationFilter{filter}, []interfaces.DestinationMiddleware{middleware})
+	sifted = Custom{}.Sift(&event, destinations, []destination_filters.DestinationFilterInterface{filter}, []destination_filters.DestinationMiddlewareInterface{middleware})
 	filter.AssertNumberOfCalls(t, "Applicable", 1)
 	filter.AssertNumberOfCalls(t, "Run", 1)
 	middleware.AssertNumberOfCalls(t, "Apply", 1)

--- a/test/internal/outgoing/dispatcher_test.go
+++ b/test/internal/outgoing/dispatcher_test.go
@@ -134,7 +134,7 @@ func TestDispatchEvents_Throttled_DelaySend(t *testing.T) {
 	throttleID := "product.update.service_one.product_id-data"
 	throttlePeriod := time.Millisecond * 500 * 2
 	store.AssertCalled(t, "Get", throttleID)
-	store.AssertCalled(t, "Set", throttleID, `{"TraceId":"","event_key":"product.update","source":"core","payload":{"field1":1},"control":null,"target_type":"Product","target_id":"product_id"}`, throttlePeriod)
+	store.AssertCalled(t, "Set", throttleID, `{"IncomingEventInterface":null,"TraceId":"","event_key":"product.update","source":"core","payload":{"field1":1},"control":null,"target_type":"Product","target_id":"product_id"}`, throttlePeriod)
 
 	time.Sleep(600 * time.Millisecond)
 
@@ -190,7 +190,7 @@ func TestDispatchEvents_Throttled_UpdatePayload(t *testing.T) {
 
 	sender.AssertNumberOfCalls(t, "SendEvent", 0)
 	store.AssertCalled(t, "Get", throttleID)
-	store.AssertCalled(t, "Update", throttleID, `{"TraceId":"","event_key":"product.update","source":"core","payload":{"field1":2},"control":null,"target_type":"Product","target_id":"product_id"}`)
+	store.AssertCalled(t, "Update", throttleID, `{"IncomingEventInterface":null,"TraceId":"","event_key":"product.update","source":"core","payload":{"field1":2},"control":null,"target_type":"Product","target_id":"product_id"}`)
 }
 
 func TestDispatchEvents_With_Document(t *testing.T) {

--- a/test/mocks/document_store_mock.go
+++ b/test/mocks/document_store_mock.go
@@ -1,20 +1,21 @@
 package mocks
 
 import (
-  "github.com/shoplineapp/captin/interfaces"
-  "github.com/shoplineapp/captin/models"
-  "github.com/stretchr/testify/mock"
+	"github.com/shoplineapp/captin/interfaces"
+	"github.com/shoplineapp/captin/models"
+	"github.com/stretchr/testify/mock"
 )
 
 // DocumentStoreMock - Mock of DocumentStoreInterface
 type DocumentStoreMock struct {
-  interfaces.DocumentStoreInterface
-  mock.Mock
+	interfaces.DocumentStoreInterface
+	mock.Mock
 }
 
 // Get - Get value from store, return with remaining time
-func (ds *DocumentStoreMock) GetDocument(e models.IncomingEvent) (map[string]interface{}) {
-  args := ds.Called(e)
-  return args.Get(0).(map[string]interface{})
+func (ds *DocumentStoreMock) GetDocument(ie interfaces.IncomingEventInterface) (map[string]interface{}) {
+	e := ie.(models.IncomingEvent)
+	args := ds.Called(e)
+	return args.Get(0).(map[string]interface{})
 }
 

--- a/test/mocks/sender_mock.go
+++ b/test/mocks/sender_mock.go
@@ -13,7 +13,9 @@ type SenderMock struct {
 }
 
 // SendEvent - Send an event
-func (s *SenderMock) SendEvent(e models.IncomingEvent, d models.Destination) error {
+func (s *SenderMock) SendEvent(ie interfaces.IncomingEventInterface, id interfaces.DestinationInterface) error {
+	e := ie.(models.IncomingEvent)
+	d := id.(models.Destination)
 	args := s.Called(e, d)
 	return args.Error(0)
 }

--- a/test/mocks/store_mock.go
+++ b/test/mocks/store_mock.go
@@ -40,6 +40,8 @@ func (s *StoreMock) Remove(key string) (bool, error) {
 }
 
 // DataKey - Generate DataKey with events and destination (Won't Mock)
-func (s *StoreMock) DataKey(e models.IncomingEvent, dest models.Destination, prefix string, suffix string) string {
-	return fmt.Sprintf("%s%s.%s.%s%s", prefix, e.Key, dest.Config.Name, e.TargetId, suffix)
+func (s *StoreMock) DataKey(ie interfaces.IncomingEventInterface, idest interfaces.DestinationInterface, prefix string, suffix string) string {
+	e := ie.(models.IncomingEvent)
+	dest := idest.(models.Destination)
+	return fmt.Sprintf("%s%s.%s.%s%s", prefix, e.Key, dest.Config.GetName(), e.TargetId, suffix)
 }

--- a/test/models/config_mapper_test.go
+++ b/test/models/config_mapper_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/shoplineapp/captin/models"
+	interfaces "github.com/shoplineapp/captin/interfaces"
 )
 
-func setup() []Configuration {
-	result := []Configuration{}
+func setup() []interfaces.ConfigurationInterface {
+	result := []interfaces.ConfigurationInterface{}
 	for i := 0; i < 3; i++ {
 		switch i {
 		case 0:
@@ -38,10 +39,10 @@ func setup() []Configuration {
 	return result
 }
 
-func getNames(configs []Configuration) []string {
+func getNames(configs []interfaces.ConfigurationInterface) []string {
 	result := []string{}
 	for _, config := range configs {
-		result = append(result, config.Name)
+		result = append(result, config.GetName())
 	}
 	return result
 }

--- a/test/senders/sqs_sender_test.go
+++ b/test/senders/sqs_sender_test.go
@@ -49,7 +49,7 @@ func TestSqsSender_SendEvent_Success(t *testing.T) {
 	result := sender.SendEvent(
 		models.IncomingEvent{},
 		models.Destination{
-			models.Configuration{},
+			Config: models.Configuration{},
 		},
 	)
 
@@ -68,7 +68,7 @@ func TestSqsSender_SendEvent_Failed(t *testing.T) {
 	result := sender.SendEvent(
 		models.IncomingEvent{Control: map[string]interface{}{"result": "failed"}},
 		models.Destination{
-			models.Configuration{Name: "failed"},
+			Config: models.Configuration{Name: "failed"},
 		},
 	)
 


### PR DESCRIPTION
Goal of this PR
- Refactor models and interfaces to avoid circular dependency
- Extract new interfaces of models to provide ability on using your own Configuration (or even incoming event later on)
- Add error handler