### PR TITLE
feat(sqs_sender): support custom aws config

### DIFF
--- a/interfaces/models.go
+++ b/interfaces/models.go
@@ -22,6 +22,7 @@ type IncomingEventInterface interface {
 
 type DestinationInterface interface {
 	GetCallbackURL() string
+	GetSqsSenderConfig(key string) string
 	GetDocumentStore() string
 }
 

--- a/models/destination.go
+++ b/models/destination.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	interfaces "github.com/shoplineapp/captin/interfaces"
+	"fmt"
 )
 
 // Destination - Event dispatch destination
@@ -25,6 +26,11 @@ func (d Destination) GetCallbackURL() string {
 		return d.callbackUrl
 	}
 	return d.Config.GetCallbackURL()
+}
+
+func (d Destination) GetSqsSenderConfig(key string) string {
+	_, value := d.Config.GetByEnv(fmt.Sprintf("SQS_SENDER_%s", key))
+	return value
 }
 
 func (d Destination) GetDocumentStore() string {


### PR DESCRIPTION
add support to supply sqs aws config through ENV variables.
```
HOOK_YOUR_HOOK_CALLBACK_URL
HOOK_YOUR_HOOK_SQS_SENDER_USE_CUSTOM_CONFIG
HOOK_YOUR_HOOK_SQS_SENDER_AWS_ENDPOINT
HOOK_YOUR_HOOK_SQS_SENDER_AWS_ACCESS_KEY
HOOK_YOUR_HOOK_SQS_SENDER_AWS_SECRET_ACCESS_KEY
HOOK_YOUR_HOOK_SQS_SENDER_AWS_REGION
```