### PR TITLE
feat(core): remove type assertion for config mapper

### DIFF
--- a/core/captin.go
+++ b/core/captin.go
@@ -45,7 +45,7 @@ func NewCaptin(configMap interfaces.ConfigMapperInterface) *Captin {
 	}
 	c := Captin{
 		Status: STATUS_READY,
-		ConfigMap: configMap.(models.ConfigurationMapper),
+		ConfigMap: configMap,
 		filters: []destination_filters.DestinationFilterInterface{
 			destination_filters.ValidateFilter{},
 			destination_filters.SourceFilter{},


### PR DESCRIPTION
it seems this change can provide more flexibility to decide how does ConfigMapper behave.

For my case, I want the method `ConfigKeys` of `MyConfigMapper` acts differently from the default one. 
I created the same struct with the same interface but modified method, but golang still warn me with 
`interfaces.ConfigMapperInterface is models.ConfigurationMapper, not MyConfigurationMapper`

I believe the root cause is golang needs the `configMapper` being the same type of the `models.ConfigurationMapper`, when we use type assertion. 

Removing this assertion is not a breaking change as the interface of `NewCaptin` has already guaranteed the provided `configMap` fulfil `interfaces.ConfigMapperInterface`