### PR TITLE
[PLAT-674] chore: replace trace_id in log with distributed tracing ID

### DIFF
--- a/models/incoming_event.go
+++ b/models/incoming_event.go
@@ -48,11 +48,12 @@ func NewIncomingEvent(data []byte) IncomingEvent {
 
 func (e IncomingEvent) GetTraceInfo() map[string]interface{} {
 	return map[string]interface{}{
-		"trace_id": e.TraceId,
-		"key":      e.Key,
-		"source":   e.Source,
-		"type":     e.TargetType,
-		"id":       e.TargetId,
+		"trace_id":          e.DistributedTracingInfo.GetTraceID(),
+		"internal_trace_id": e.TraceId,
+		"key":               e.Key,
+		"source":            e.Source,
+		"type":              e.TargetType,
+		"id":                e.TargetId,
 	}
 }
 

--- a/models/incoming_event.go
+++ b/models/incoming_event.go
@@ -49,7 +49,7 @@ func NewIncomingEvent(data []byte) IncomingEvent {
 func (e IncomingEvent) GetTraceInfo() map[string]interface{} {
 	return map[string]interface{}{
 		"trace_id":          e.DistributedTracingInfo.GetTraceID(),
-		"internal_trace_id": e.TraceId,
+		"trace_internal_id": e.TraceId,
 		"key":               e.Key,
 		"source":            e.Source,
 		"type":              e.TargetType,

--- a/test/models/incoming_event_test.go
+++ b/test/models/incoming_event_test.go
@@ -108,12 +108,12 @@ func TestIsValid(t *testing.T) {
 func TestMarshalJSON(t *testing.T) {
 	val, err := sampleIncomingEvent.MarshalJSON()
 	require.NoError(t, err)
-	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","key":"product.update","source":"core","trace_id":"11111111-2222-3333-4444-555555555555","type":"product"}`, string(val))
+	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","internal_trace_id":"11111111-2222-3333-4444-555555555555","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","type":"product"}`, string(val))
 }
 
 func TestString(t *testing.T) {
 	val := sampleIncomingEvent.String()
-	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","key":"product.update","source":"core","trace_id":"11111111-2222-3333-4444-555555555555","type":"product"}`, string(val))
+	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","internal_trace_id":"11111111-2222-3333-4444-555555555555","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","type":"product"}`, string(val))
 }
 
 func TestToMap(t *testing.T) {

--- a/test/models/incoming_event_test.go
+++ b/test/models/incoming_event_test.go
@@ -108,12 +108,12 @@ func TestIsValid(t *testing.T) {
 func TestMarshalJSON(t *testing.T) {
 	val, err := sampleIncomingEvent.MarshalJSON()
 	require.NoError(t, err)
-	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","internal_trace_id":"11111111-2222-3333-4444-555555555555","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","type":"product"}`, string(val))
+	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","trace_internal_id":"11111111-2222-3333-4444-555555555555","type":"product"}`, string(val))
 }
 
 func TestString(t *testing.T) {
 	val := sampleIncomingEvent.String()
-	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","internal_trace_id":"11111111-2222-3333-4444-555555555555","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","type":"product"}`, string(val))
+	assert.Equal(t, `{"control":{"host":"host","ip_addresses":"ip_addresses","ts":99999999999999},"id":"xxxxx","key":"product.update","source":"core","trace_id":"11111111111111111111111111111111","trace_internal_id":"11111111-2222-3333-4444-555555555555","type":"product"}`, string(val))
 }
 
 func TestToMap(t *testing.T) {


### PR DESCRIPTION
The old `trace_id` is replaced by `internal_trace_id`.
It should allow direct linking from Loki to Tempo on Grafana.

This PR also fixes the wrong `Triggering dispatch more than once` warning.