### PR TITLE
feat(PLAT-1296): add span for replacing throttled document for delaye…

### DIFF
--- a/internal/outgoing/dispatcher.go
+++ b/internal/outgoing/dispatcher.go
@@ -378,6 +378,7 @@ func (d *Dispatcher) processDelayedEvent(ctx context.Context, e models.IncomingE
 
 	if dataExists {
 		// Update Value
+		span.AddEvent("Replacing throttled document delayed event", trace.WithAttributes(attribute.String("data_key", dataKey), attribute.String("trace_id", e.DistributedTracingInfo.GetTraceID())))
 		_, updateErr := store.Update(ctx, dataKey, string(jsonString))
 		if updateErr != nil {
 			panic(updateErr)


### PR DESCRIPTION
# Why:
We would like to add a new tracing span to observe how the replacing throttled document works

# How:
We add a new span when it replace the document and also show the trace_id for which replacing it

![image](https://github.com/user-attachments/assets/9ec5c28c-3e3d-4349-8e33-9cfc4531e849)
<img width="2549" alt="image" src="https://github.com/user-attachments/assets/4f86ab85-6841-4c89-bc87-88f53c87cff7" />

